### PR TITLE
Fix typo in PKGBUILD /ush -> /usr

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -28,7 +28,7 @@ package() {
   install -D -m 644 "$srcdir/$pkgname.session" \
     "$pkgdir/usr/share/cinnamon-session/sessions/$pkgname.session"
 
-  msg "Install $pkgname in /ush/share/applications"
+  msg "Install $pkgname in /usr/share/applications"
   install -D -m 644 "$srcdir/$pkgname-app.desktop" \
     "$pkgdir/usr/share/applications/$pkgname.desktop"
 


### PR DESCRIPTION
I noticed that there seemed to be a typo in the PKGBUILD.

Thanks for your work putting this together! I found the repo very helpful in getting i3 and cinnamon running on my Manjaro install.